### PR TITLE
fix build on linux

### DIFF
--- a/buildroot/share/PlatformIO/scripts/generic_create_variant.py
+++ b/buildroot/share/PlatformIO/scripts/generic_create_variant.py
@@ -52,7 +52,7 @@ if pioutil.is_pio_build():
         variant_dir.mkdir()
 
     # Source dir is a local variant sub-folder
-    source_dir = Path("buildroot/share/PlatformIO/variants", variant)
+    source_dir = Path("buildroot/share/PlatformIO/variants", variant.upper())
     assert source_dir.is_dir()
 
     marlin.copytree(source_dir, variant_dir)


### PR DESCRIPTION
### Description

On Linux, file systems are typically case sensitive. This causes a build failure because the `variant` is given as `marlin_CREALITY_STM32F401RC` while the path on the file system is `buildroot/share/PlatformIO/variants/MARLIN_CREALITY_STM32F401RC`.

### Requirements

No.

### Benefits

I can build on linux!

### Configurations

N/A

### Related Issues

N/A
