### PR TITLE
There is a bug in the code

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/dwin.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin.h
@@ -110,7 +110,7 @@ typedef struct {
   int16_t BedPidT = DEF_BEDPIDT;
   int16_t PidCycles = DEF_PIDCYCLES;
   int16_t ExtMinT = EXTRUDE_MINTEMP;
-  int16_t BedLevT = LEVELING_BED_TEMP;
+  # int16_t BedLevT = LEVELING_BED_TEMP; # I commented this line out, after commenting this out I can succesfully compile without errors.
   bool Baud115K = ENABLED(BAUD_RATE_GCODE) ? (BAUDRATE == 115200) : false;
   bool FullManualTramming = false;
   bool MediaAutoMount = ENABLED(HAS_SD_EXTENDER);


### PR DESCRIPTION
The bug is not in the official marlin 2.1.x bugfixes folder but I can find him here. If you try to compile marlin with your marlin-folder you get an error:

Marlin\src\lcd/e3v2/proui/dwin.h:123:21: error: 'LEVELING_BED_TEMP' was not declared in this scope
  123 |   int16_t BedLevT = LEVELING_BED_TEMP;
      |    

This error occurs because the variable "LEVELING_BED_TEMP" doesn't exist if disable Preheat before levelling ==> //#define PREHEAT_BEFORE_LEVELING

You should implement a way to only use the "LEVELING_BED_TEMP"-variable when "PREHEAT_BEFORE_LEVELING" is enabled.

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
