### PR TITLE
Fix wrong parenthesis in the dwin.cpp file

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -1717,7 +1717,7 @@ void DWIN_SetDataDefaults() {
   #endif
   #if BOTH(LED_CONTROL_MENU, HAS_COLOR_LEDS)
     #if ENABLED(LED_COLOR_PRESETS)
-      leds.set_default());
+      leds.set_default();
       ApplyLEDColor();
     #else
       HMI_data.Led_Color = Def_Leds_Color;


### PR DESCRIPTION
### Description

While compiling custom configuration I noticed this wrongly placed parenthesis and decided to create a pr fixing it and keep you informed.

