### PR TITLE
fix M575 gcode for multi-UART port cofiguration

### DIFF
--- a/Marlin/src/gcode/config/M575.cpp
+++ b/Marlin/src/gcode/config/M575.cpp
@@ -53,6 +53,7 @@ void GcodeSuite::M575() {
     case 115200: case 250000: case 500000: case 1000000: {
       const int8_t port = parser.intval('P', -99);
       const bool set1 = (port == -99 || port == 0);
+        const bool set2 = (port == -99 || port == 1);
 
       SERIAL_FLUSH();
 
@@ -66,7 +67,6 @@ void GcodeSuite::M575() {
 
       if (set1) SERIAL_ECHO_MSG(" Serial ", AS_DIGIT(0), " baud rate set to ", baud);
       #if HAS_MULTI_SERIAL
-        const bool set2 = (port == -99 || port == 1);
         if (set2) SERIAL_ECHO_MSG(" Serial ", AS_DIGIT(1), " baud rate set to ", baud);
         #ifdef SERIAL_PORT_3
           const bool set3 = (port == -99 || port == 2);


### PR DESCRIPTION
### Description

Enabling SERIAL_PORT_2 results in a compilation error due to variable declared after first usage

### Requirements

Configuration.h
```
#define SERIAL_PORT_2 2
```

### Benefits

Fix compilation error :)

### Configurations

Configuration attached: 
[config.zip](https://github.com/mriscoc/Ender3V2S1/files/14633624/config.zip)


### Related Issues
No