### PR TITLE
Fix compilation issue in multi-uart setup

### DIFF
--- a/Marlin/src/gcode/config/M575.cpp
+++ b/Marlin/src/gcode/config/M575.cpp
@@ -53,6 +53,7 @@ void GcodeSuite::M575() {
     case 115200: case 250000: case 500000: case 1000000: {
       const int8_t port = parser.intval('P', -99);
       const bool set1 = (port == -99 || port == 0);
+        const bool set2 = (port == -99 || port == 1);
 
       SERIAL_FLUSH();
 
@@ -66,7 +67,6 @@ void GcodeSuite::M575() {
 
       if (set1) SERIAL_ECHO_MSG(" Serial ", AS_DIGIT(0), " baud rate set to ", baud);
       #if HAS_MULTI_SERIAL
-        const bool set2 = (port == -99 || port == 1);
         if (set2) SERIAL_ECHO_MSG(" Serial ", AS_DIGIT(1), " baud rate set to ", baud);
         #ifdef SERIAL_PORT_3
           const bool set3 = (port == -99 || port == 2);

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1039,7 +1039,7 @@
 
 // E3V2 extras
 #if HAS_DWIN_E3V2 || IS_DWIN_MARLINUI
-  #define SERIAL_CATCHALL 0
+  //#define SERIAL_CATCHALL 0
   #define HAS_LCD_BRIGHTNESS 1
   #ifdef TJC_DISPLAY
     #define LCD_BRIGHTNESS_MIN 6


### PR DESCRIPTION
### Description

This pull request fixes 2 issues (one per commit) after enabling second UART:
1. M575 gcode - wrong variable declaration - it declared after first usage, so it leads to compilation error
2. define SERIAL_CATCHALL - I checked all usage for this define. In one-UART it dose not used, after enabling second UART it leads to multiple compilation error in `serial.h` because in line 76 define `_SERIAL_LEAF_2` defines to number. I spend a lot of time to found reason and recheck it, and at now I'm sure that SERIAL_CATCHALL must be removed. I use firmware with this fix for a few weaks, all works fine.

### Requirements

Enabling second UART in Configuration.h:
```
#define SERIAL_PORT_2 2
```

I use board BQ skr mini E3, but I think this errors appears at any board after enabling second UART

### Benefits

This pull request fixes compilation errors :)

### Configurations

Attached: 
[config.zip](https://github.com/mriscoc/Ender3V2S1/files/14633919/config.zip)


### Related Issues

No
